### PR TITLE
Add "pull-params" option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   command:
     description: 'Command to run inside image'
     default: 'ls -al'
+  pull-params:
+    description: 'Extra parameters to pass to `docker pull`'
+    default: ''
   params:
     description: 'Extra parameters to pass to `docker run`'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ inputs:
     # By using the same host:guest mapping, the host $PATH is valid in both
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ var github = require('@actions/github');
 var dockerCommand = require('docker-cli-js').dockerCommand;
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var image, hostDir, guestDir, command, params, error_1;
+        var image, hostDir, guestDir, command, params, pparams, error_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -49,9 +49,10 @@ function run() {
                     guestDir = core.getInput('guest-dir');
                     command = core.getInput('command');
                     params = core.getInput('params');
+                    pparams = core.getInput('pull-params');
                     core.info("Host PATH: " + process.env.PATH);
                     // pull the required machine
-                    return [4 /*yield*/, dockerCommand("pull " + image)];
+                    return [4 /*yield*/, dockerCommand("pull " + pparams + " " + image)];
                 case 1:
                     // pull the required machine
                     _a.sent();


### PR DESCRIPTION
Add a new option "pull-params" to the action to specify options
for "docker pull".

This allows using the "--platform" option with this action
(because it has to be set for both "docker run" and "docker pull").
Useful for running multi-platform containers, e.g. using 
dbhi/qus/action@main.
