### PR TITLE
Reinstate "--pull-params" after node20 update

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,9 +19,10 @@ function run() {
             const guestDir = core.getInput('guest-dir');
             const command = core.getInput('command');
             const params = core.getInput('params');
+            const pull_params = core.getInput('pull-params');
             core.info(`Host PATH: ${process.env.PATH}`);
             // pull the required machine
-            yield dockerCommand(`pull ${image}`);
+            yield dockerCommand(`pull ${pull_params} ${image}`);
             core.info(`Pulled OK: ${image}`);
             // run it
             yield dockerCommand(`run ${params} -w ${guestDir} -v${hostDir}:${guestDir} ${image} ${command}`);


### PR DESCRIPTION
The last commit that updated the action to node20 ignored the `--pull-params` option. Fix it.

Fixes #8.
