### PR TITLE
Reinstate "--pull-params" after node20 update

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,9 +19,10 @@ function run() {
             const guestDir = core.getInput('guest-dir');
             const command = core.getInput('command');
             const params = core.getInput('params');
+            const pull_params = core.getInput('pull-params');
             core.info(`Host PATH: ${process.env.PATH}`);
             // pull the required machine
-            yield dockerCommand(`pull ${image}`);
+            yield dockerCommand(`pull ${pull_params} ${image}`);
             core.info(`Pulled OK: ${image}`);
             // run it
             yield dockerCommand(`run ${params} -w ${guestDir} -v${hostDir}:${guestDir} ${image} ${command}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,11 +9,12 @@ async function run() {
       const guestDir : string = core.getInput('guest-dir');
       const command  : string = core.getInput('command');
       const params   : string = core.getInput('params');
+      const pull_params   : string = core.getInput('pull-params');
 
       core.info(`Host PATH: ${process.env.PATH}`);
 
       // pull the required machine
-      await dockerCommand(`pull ${image}`);
+      await dockerCommand(`pull ${pull_params} ${image}`);
       core.info(`Pulled OK: ${image}`);
 
       // run it


### PR DESCRIPTION
The last commit that updated the action to node20 ignored the `--pull-params` option. Fix it.

The last commit that updated the action to node20 ignored the `--pull-params` option. Fix it.

Fixes #8.
Replaces #9 and #10 (now with fix to `src/main.ts`, and proper branch naming).